### PR TITLE
Fixed unused index issue

### DIFF
--- a/litedb/table/persistent_table.py
+++ b/litedb/table/persistent_table.py
@@ -138,7 +138,7 @@ class PersistentTable(Table):
             index = self._unused_indexes.pop()
         else:
             index = self._size
-            self._shard_manager.insert(item, index)
+        self._shard_manager.insert(item, index)
         self._size += 1
         self._index_manager.index_item(item, index)
         self._modified = True

--- a/tests/test_table/test_persistent_table.py
+++ b/tests/test_table/test_persistent_table.py
@@ -74,3 +74,15 @@ def test_retrieve_some(table, test_objects):
     for item in test_objects:
         table._insert(item)
     assert list(table.retrieve(good_index=(GoodIndex(0), GoodIndex(10)))) == test_objects[:11]
+
+
+def test_table_unused_indexes(table, test_objects, table_dir):
+    for item in test_objects:
+        table._insert(item)
+    table.delete(good_index=GoodIndex(1))
+    table._insert(GoodObject(1))
+    table.commit()
+    del table
+    table = PersistentTable._from_file(table_dir)
+    assert list(table.retrieve(good_index=(GoodIndex(0), GoodIndex(10)))) == test_objects[:11]
+


### PR DESCRIPTION
If the database had unused indexes, then the database would not actually insert the item as expected.